### PR TITLE
fix: add default paginated params

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -300,7 +300,7 @@ pub struct ProgressNotificationParams {
 }
 
 /// A structure for request parameters that may involve pagination.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PaginatedParams {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -921,6 +921,7 @@ pub enum ClientRequest {
         #[serde(rename = "jsonrpc")]
         json_rpc: String,
         id: RequestId,
+        #[serde(default)]
         params: PaginatedParams,
     },
     #[serde(rename = "resources/list")]
@@ -928,6 +929,7 @@ pub enum ClientRequest {
         #[serde(rename = "jsonrpc")]
         json_rpc: String,
         id: RequestId,
+        #[serde(default)]
         params: PaginatedParams,
     },
     #[serde(rename = "resources/templates/list")]
@@ -935,6 +937,7 @@ pub enum ClientRequest {
         #[serde(rename = "jsonrpc")]
         json_rpc: String,
         id: RequestId,
+        #[serde(default)]
         params: PaginatedParams,
     },
     #[serde(rename = "resources/read")]
@@ -970,6 +973,7 @@ pub enum ClientRequest {
         #[serde(rename = "jsonrpc")]
         json_rpc: String,
         id: RequestId,
+        #[serde(default)]
         params: PaginatedParams,
     },
 }


### PR DESCRIPTION
The protocol defines paginated params in requests as optional. In [the schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json), only the method field is required for requests like ListToolsRequest, and some clients like Cursor appear to follow this and not pass a params field at all.